### PR TITLE
Fix foo's client compatibility (#30)

### DIFF
--- a/src/bluearchive/audio/ArchivDSoundControl.java
+++ b/src/bluearchive/audio/ArchivDSoundControl.java
@@ -200,7 +200,7 @@ public class ArchivDSoundControl extends SoundControl {
                 if (Musics.menu != tree.loadMusic("menure-aoh")) Musics.menu = !LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM")).equals("01-04") ? tree.loadMusic("menure-aoh") : ArchivDMusic.funnyAhh;
                 break;
             case "recollection":
-                if (Musics.menu != recollectionMusic) Musics.menu = !LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM")).equals("01-04") ? recollectionMusic : ArchivDMusic.funnyAhh;
+                if (Musics.menu != recollectionMusic && recollectionMusic != null) Musics.menu = !LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM")).equals("01-04") ? recollectionMusic : ArchivDMusic.funnyAhh;
                 break;
         }
     }


### PR DESCRIPTION
Foo's reorders some load tasks to optimize startup time. When this mod is running in foo's client, recollectionMusic can still be null at the time replaceMainMenu runs. Add null check to avoid crash.